### PR TITLE
No job ID

### DIFF
--- a/histomics_label/__init__.py
+++ b/histomics_label/__init__.py
@@ -1,4 +1,9 @@
+import datetime
 from girder import plugin
+from girder import events
+from girder.models.file import File
+from girder.models.notification import Notification
+import yaml
 
 
 class GirderPlugin(plugin.GirderPlugin):
@@ -8,3 +13,25 @@ class GirderPlugin(plugin.GirderPlugin):
     def load(self, info):
         # add plugin loading logic here
         plugin.getPlugin('histomicsui').load(info)
+
+        # Set up event handler for config file updates
+        def onConfigUpdate(event):
+            file = event.info["file"]
+            if file.get("name") == ".histomicsui_config.yaml":
+                with File().open(file) as f:
+                    config = yaml.safe_load(f)
+                initialTrainingParameters = {
+                    'radius': config.get('radius', None),
+                    'magnification': config.get('magnification', None),
+                    'certainty': config.get('certainty', None),
+                    'feature': config.get('feature', None)
+                }
+                Notification().createNotification(
+                    type='histomics_label.config_updated',
+                    data=initialTrainingParameters,
+                    user=event.info["currentUser"],
+                    expires=(datetime.datetime.now(datetime.timezone.utc) +
+                                datetime.timedelta(seconds=30))
+                    )
+
+        events.bind('data.process', 'histomics_label', onConfigUpdate)

--- a/histomics_label/web_client/views/body/ActiveLearningView.js
+++ b/histomics_label/web_client/views/body/ActiveLearningView.js
@@ -690,18 +690,20 @@ const ActiveLearningView = View.extend({
         this.applyReviews();
         // Make sure that our folder ids are up-to-date
         const data = this.generateClassificationJobData();
-        data.jobId = this.lastRunJobId;
         data.randomInput = false;
+        data.train = true;
         const excluded = _.map(store.exclusions, (idx) => store.categories[idx + 1].label);
+        data.exclude = JSON.stringify(excluded);
+        if (!this.lastRunJobId) {
+            const { radius, magnification, certaintyMetric, featureShape } = this.histomicsUIConfig;
+            this.generateInitialSuperpixels(radius, magnification, certaintyMetric, featureShape);
+            return;
+        }
+        data.jobId = this.lastRunJobId;
         restRequest({
             method: 'POST',
             url: `slicer_cli_web/${this.activeLearningJobUrl}/rerun`,
-            data: {
-                jobId: this.lastRunJobId,
-                randominput: false,
-                train: true,
-                exclude: JSON.stringify(excluded)
-            }
+            data
         }).done((job) => {
             store.page = 0;
             store.selectedIndex = 0;

--- a/histomics_label/web_client/views/body/ActiveLearningView.js
+++ b/histomics_label/web_client/views/body/ActiveLearningView.js
@@ -695,8 +695,7 @@ const ActiveLearningView = View.extend({
         const excluded = _.map(store.exclusions, (idx) => store.categories[idx + 1].label);
         data.exclude = JSON.stringify(excluded);
         if (!this.lastRunJobId) {
-            const { radius, magnification, certaintyMetric, featureShape } = this.histomicsUIConfig;
-            this.generateInitialSuperpixels(radius, magnification, certaintyMetric, featureShape);
+            this.initialTraining(radius, magnification, certaintyMetric, featureShape);
             return;
         }
         data.jobId = this.lastRunJobId;
@@ -737,7 +736,7 @@ const ActiveLearningView = View.extend({
         };
     },
 
-    generateInitialSuperpixels(radius, magnification, certaintyMetric, featureShape) {
+    initialTraining(radius, magnification, certaintyMetric, featureShape) {
         const data = this.generateClassificationJobData();
         Object.assign(data, {
             labels: JSON.stringify([]),

--- a/histomics_label/web_client/views/body/ActiveLearningView.js
+++ b/histomics_label/web_client/views/body/ActiveLearningView.js
@@ -3,8 +3,10 @@ import View from '@girder/core/views/View';
 import { restRequest, getApiRoot } from '@girder/core/rest';
 import { confirm } from '@girder/core/dialog';
 import _ from 'underscore';
+import events from '@girder/core/events';
 
 import router from '@girder/histomicsui/router';
+import eventStream from '@girder/core/utilities/EventStream';
 import FolderCollection from '@girder/core/collections/FolderCollection';
 import AnnotationModel from '@girder/large_image_annotation/models/AnnotationModel';
 import ItemCollection from '@girder/core/collections/ItemCollection';
@@ -66,6 +68,13 @@ const ActiveLearningView = View.extend({
         // Use a map to preserve insertion order
         this.categoryMap = new Map();
         this.histomicsUIConfig = {};
+
+        events.listenTo(eventStream, 'g:event.histomics_label.config_updated', (event) => {
+            Object.entries(event.data).forEach(([key, value]) => {
+                this.histomicsUIConfig[key] = value;
+                store.initialTrainingParameters[key] = value;
+            });
+        });
 
         this.mountToolbarComponent();
         this.getCurrentUser();

--- a/histomics_label/web_client/views/vue/components/ActiveLearningLabeling.vue
+++ b/histomics_label/web_client/views/vue/components/ActiveLearningLabeling.vue
@@ -788,9 +788,9 @@ export default Vue.extend({
         class="btn btn-block"
         :class="[activeLearningStep < activeLearningSteps.GuidedLabeling ? 'btn-primary' : 'btn-success']"
         :disabled="!currentCategoryFormValid || !currentLabelsValid || blockingJobRunning"
-        @click="beginTraining"
         data-toggle="tooltip"
         :title="blockingJobRunning ? 'Training in progress' : ''"
+        @click="beginTraining"
       >
         <i class="icon-star" />
         {{ activeLearningStep < activeLearningSteps.GuidedLabeling ? 'Begin training' : 'Retrain' }}

--- a/histomics_label/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/histomics_label/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -1,19 +1,47 @@
 <script>
 import Vue from 'vue';
 
+import { activeLearningSteps } from '../constants.js';
+
+import { store } from '../store.js';
+
 export default Vue.extend({
     props: ['backboneParent', 'certaintyMetrics', 'featureShapes'],
-    data() {
-        return {
-            radius: 100,
-            magnification: 5,
-            certaintyChoice: '',
-            featureChoice: ''
-        };
-    },
     computed: {
         validForm() {
             return this.radius > 0 && this.magnification > 0;
+        },
+        radius: {
+            get() {
+                return store.initialTrainingParameters.radius || 100;
+            },
+            set(value) {
+                store.initialTrainingParameters.radius = value;
+            }
+        },
+        magnification: {
+            get() {
+                return store.initialTrainingParameters.magnification || 5;
+            },
+            set(value) {
+                store.initialTrainingParameters.magnification = value;
+            }
+        },
+        certaintyChoice: {
+            get() {
+                return store.initialTrainingParameters.certainty;
+            },
+            set(value) {
+                store.initialTrainingParameters.certainty = value;
+            }
+        },
+        featureChoice: {
+            get() {
+                return store.initialTrainingParameters.feature;
+            },
+            set(value) {
+                store.initialTrainingParameters.feature = value;
+            }
         }
     },
     mounted() {
@@ -22,12 +50,15 @@ export default Vue.extend({
     },
     methods: {
         initialTraining() {
-            this.backboneParent.initialTraining(
-                this.radius,
-                this.magnification,
-                this.certaintyChoice,
-                this.featureChoice
-            );
+            store.activeLearningStep = activeLearningSteps.InitialLabeling;
+            store.initialTrainingParameters = {
+                radius: this.radius,
+                magnification: this.magnification,
+                certainty: this.certaintyChoice,
+                feature: this.featureChoice
+            };
+            this.backboneParent.initialTraining();
+            this.backboneParent.updateHistomicsYamlConfig();
         }
     }
 });

--- a/histomics_label/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
+++ b/histomics_label/web_client/views/vue/components/ActiveLearningSetup/ActiveLearningInitialSuperpixels.vue
@@ -21,8 +21,8 @@ export default Vue.extend({
         this.featureChoice = this.featureShapes[0];
     },
     methods: {
-        generateInitialSuperpixels() {
-            this.backboneParent.generateInitialSuperpixels(
+        initialTraining() {
+            this.backboneParent.initialTraining(
                 this.radius,
                 this.magnification,
                 this.certaintyChoice,
@@ -98,7 +98,7 @@ export default Vue.extend({
     <button
       class="btn btn-primary h-generate-superpixel-btn"
       :disabled="!validForm"
-      @click="generateInitialSuperpixels"
+      @click="initialTraining"
     >
       Generate Superpixels
     </button>

--- a/histomics_label/web_client/views/vue/components/store.js
+++ b/histomics_label/web_client/views/vue/components/store.js
@@ -29,6 +29,7 @@ const store = Vue.observable({
     userNames: {},
     exclusions: [],
     tileMetadata: {},
+    initialTrainingParameters: {},
     /*********
      * UI
      *********/


### PR DESCRIPTION
This PR provides a solution for projects that may not have a previous job id associated with them (which was required in order to request further training). As an alternative, the values typically set in the initial superpixel generation step can be set in the `.histomicsui_config.yaml` file:
- `radius`: The size of superpixels generated (UI defaults to `100`)
- `magnification`: The magnification level at which to generate the superpixels (UI defaults to `5`)
- `certainty`: The metric used to determine the order that predictions are presented to the user (UI defaults to `confidence`). Options are `confidence`, `margin`, `negative_entropy`, or `batchbald`.
- `feature`: The feature shape. Either superpixel image data (`image`) or foundation model vector (`vector`). The UI defaults to `image`.

If training is requested and there is no job id and the `radius`, `magnification`, `certainty`, and/or `feature` keys are not set in the config file, you will be notified of which are missing and have the option to open the config and set the missing values.

![image](https://github.com/user-attachments/assets/684e1da6-6799-445c-9e7b-2f3116aa5a4e)

**NOTE**: There is a bug around setting values in the config. Specifically, if a string value is set with single quotes (for example `feature: 'image'`) at the end of the file and there is a new line at the end (either added manually or automatically by using the `Format` button) then the UI is not automatically notified of the change and will think that the value is still missing. This can be avoided by any of the following:
- not listing string values last
```
radius: 100                        certainty: 'confidence' 
magnification: 5                   feature: 'image'
certainty: 'confidence'     ->     radius: 100
feature: 'image'                   magnification: 5
```
- not using quotes around the string value
```
feature: 'image'     ->     feature: image
```
- refreshing the UI after updating the config file